### PR TITLE
Update unit testing workflow to use 'uv run' for executing tests

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -41,4 +41,4 @@ jobs:
         uses: astral-sh/ruff-action@v3
 
       - name: Run Tests
-        run: pytest tests -vv
+        run: uv run pytest tests -vv


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/unit_tests.yml` file. The change updates the command used to run unit tests, replacing `pytest` with `uv run pytest` for better integration with the testing environment.