### PR TITLE
Update CI workflow to exclude unsupported Python versions

### DIFF
--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -17,13 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest, macos-14]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
-        exclude:
-          # Python <3.8 isn't available on macOS-14 yet (adjust when supported)
-          - os: macos-14
-            python-version: '3.6'
-          - os: macos-14
-            python-version: '3.7'
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
This pull request updates the Python version matrix in the `.github/workflows/pypi_release.yml` file to remove support for Python 3.6 and 3.7. The exclusion rules for macOS-14 related to these versions have also been removed.

Python version matrix updates:

* [`.github/workflows/pypi_release.yml`](diffhunk://#diff-8768f9c965675da52951814b927f7a3831959cd45b7185cba81f28982dd80583L20-R20): Removed Python 3.6 and 3.7 from the `python-version` matrix and deleted exclusion rules for macOS-14 that were previously necessary for these versions.