### PR TITLE
Improve query handling

### DIFF
--- a/mockylla/parser/utils.py
+++ b/mockylla/parser/utils.py
@@ -63,6 +63,8 @@ def get_table(table_name_full, session, state):
 
 def parse_where_clause(where_clause_str, schema):
     """Parse WHERE clause conditions into structured format."""
+    where_clause_str = where_clause_str.rstrip(";")
+
     if not where_clause_str:
         return []
 

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -1,0 +1,20 @@
+from cassandra.cluster import Cluster
+from mockylla import mock_scylladb
+
+
+@mock_scylladb
+def test_demo():
+    s = Cluster().connect()
+    s.execute(
+        "CREATE KEYSPACE ks WITH replication = {'class':'SimpleStrategy','replication_factor':1}"
+    )
+    s.set_keyspace("ks")
+    s.execute("CREATE TABLE t (id int PRIMARY KEY, v text)")
+    s.execute("INSERT INTO t (id, v) VALUES (1,'A')")
+    s.execute("INSERT INTO t (id, v) VALUES (2,'B')")
+
+    # statement ending with semicolon
+    s.execute("DELETE FROM t WHERE id = 2;")
+    rows = list(s.execute("SELECT * FROM t;"))
+    assert len(rows) == 1 and rows[0]["id"] == 1
+    print("semicolon-safe ✅")

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -13,8 +13,6 @@ def test_demo():
     s.execute("INSERT INTO t (id, v) VALUES (1,'A')")
     s.execute("INSERT INTO t (id, v) VALUES (2,'B')")
 
-    # statement ending with semicolon
     s.execute("DELETE FROM t WHERE id = 2;")
     rows = list(s.execute("SELECT * FROM t;"))
     assert len(rows) == 1 and rows[0]["id"] == 1
-    print("semicolon-safe ✅")

--- a/tests/test_semicolon_handling.py
+++ b/tests/test_semicolon_handling.py
@@ -1,0 +1,74 @@
+import uuid
+from mockylla import mock_scylladb
+from cassandra.cluster import Cluster
+
+
+@mock_scylladb
+def test_semicolon_handling_in_loop():
+    """Ensure that terminating semicolons do not break WHERE-clause filtering in a delete / update loop."""
+
+    cluster = Cluster(["127.0.0.1"])
+    session = cluster.connect()
+
+    keyspace = "test_keyspace"
+    session.execute(
+        f"CREATE KEYSPACE {keyspace} WITH replication = {{'class':'SimpleStrategy','replication_factor':1}};"
+    )
+    session.set_keyspace(keyspace)
+
+    session.execute(
+        """
+        CREATE TABLE counter_table (
+            group_id text PRIMARY KEY,
+            counter_value counter
+        );
+        """
+    )
+    session.execute(
+        """
+        CREATE TABLE images_data (
+            group_id text,
+            id timeuuid,
+            data text,
+            PRIMARY KEY (group_id, id)
+        ) WITH CLUSTERING ORDER BY (id DESC);
+        """
+    )
+
+    payload_template = '{"purpose": "test"}'
+    inserts = [("groupA", uuid.uuid1()) for _ in range(7)] + [
+        ("groupB", uuid.uuid1()) for _ in range(5)
+    ]
+    for stack, uid in inserts:
+        session.execute(
+            """
+            INSERT INTO images_data (
+                group_id,
+                id,
+                data
+            ) VALUES (%s, %s, %s);
+            """,
+            (stack, uid, payload_template),
+        )
+        session.execute(
+            """
+            UPDATE counter_table SET counter_value = counter_value + 1 WHERE group_id = %s;
+            """,
+            (stack,),
+        )
+
+    while rows := list(session.execute("SELECT * FROM images_data LIMIT 6;")):
+        for row in rows:
+            session.execute(
+                "DELETE FROM images_data WHERE id = %s AND group_id = %s;",
+                (row.id, row.group_id),
+            )
+            session.execute(
+                "UPDATE counter_table SET counter_value = counter_value - 1 WHERE group_id = %s;",
+                (row.group_id,),
+            )
+
+    assert list(session.execute("SELECT * FROM images_data;")) == []
+
+    for row in session.execute("SELECT * FROM counter_table;"):
+        assert row.counter_value == 0


### PR DESCRIPTION
This pull request includes changes to improve WHERE-clause handling and adds new tests to ensure proper functionality of database operations. The most important changes include fixing a bug related to semicolon handling in WHERE clauses, adding a demo test for basic ScyllaDB operations, and introducing a comprehensive test for semicolon handling in a loop.

### Bug Fixes:
* [`mockylla/parser/utils.py`](diffhunk://#diff-676626ac6f1a4f48be607d802df509481987d99d94d6ac2fdb157d06bc05e967R66-R67): Fixed an issue where trailing semicolons in WHERE clauses could cause parsing errors by stripping semicolons from the input string.

### New Tests:
* [`tests/test_demo.py`](diffhunk://#diff-bbb7d5672ea99d35dd492bd3cddc80ff0bce8b045105546473377571626f1b65R1-R18): Added a demo test to validate basic ScyllaDB operations, including keyspace creation, table creation, insertion, deletion, and query execution.
* [`tests/test_semicolon_handling.py`](diffhunk://#diff-2ed6e8ae0242af82be4c4d8c680957b1b6d4e2e86ee7406175131b11d3acb3b7R1-R74): Introduced a test to ensure terminating semicolons do not break WHERE-clause filtering in a delete/update loop, covering scenarios with counters and clustering keys.