### PR TITLE
Bump version 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mockylla"
-version = "0.2.0"
+version = "0.3.0"
 description = "A mock for the ScyllaDB Python driver for testing purposes."
 readme = "README.md"
 requires-python = ">=3.8,<3.12"

--- a/tests/test_fixture_autouse.py
+++ b/tests/test_fixture_autouse.py
@@ -1,0 +1,50 @@
+import pytest
+from cassandra.cluster import Cluster
+from mockylla import MockScyllaDB, get_table_rows
+
+
+@pytest.fixture(scope="module", autouse=True)
+def scylla_mock():
+    """Start the mock, create a keyspace/table and insert some rows."""
+
+    with MockScyllaDB():
+        cluster = Cluster(["127.0.0.1"])
+        session = cluster.connect()
+
+        keyspace_name = "preload"
+        table_name = "items"
+
+        session.execute(
+            f"CREATE KEYSPACE {keyspace_name} "
+            "WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 1}"
+        )
+        session.set_keyspace(keyspace_name)
+        session.execute(
+            f"CREATE TABLE {table_name} (id int PRIMARY KEY, value text)"
+        )
+
+        session.execute(
+            f"INSERT INTO {table_name} (id, value) VALUES (1, 'foo')"
+        )
+        session.execute(
+            f"INSERT INTO {table_name} (id, value) VALUES (2, 'bar')"
+        )
+
+        yield
+
+
+def test_preloaded_row_count():
+    """Ensure the fixture inserted exactly two rows."""
+    rows = get_table_rows("preload", "items")
+    assert len(rows) == 2
+
+
+def test_query_returns_expected_value():
+    """Run a SELECT query and check that the correct row is returned."""
+    cluster = Cluster(["127.0.0.1"])
+    session = cluster.connect("preload")
+
+    result = session.execute("SELECT value FROM items WHERE id = 2")
+    row = result.one()
+
+    assert row.value == "bar"


### PR DESCRIPTION
This pull request introduces a new version of the `mockylla` package and adds comprehensive tests for preloaded data using an autouse fixture. The most important changes include updating the version in `pyproject.toml` and introducing a new test file with a module-scoped fixture and two test cases.

### Package version update:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7): Updated the package version from `0.2.0` to `0.3.0`, indicating a new release.

### New test file with autouse fixture:

* [`tests/test_fixture_autouse.py`](diffhunk://#diff-0156f3c4d5e7cee26f7700ce82174b965da58aed77751f31d0b14dc52e72d882R1-R50): Added a module-scoped `pytest` fixture to mock a ScyllaDB instance, create a keyspace and table, and insert preloaded data for testing. This fixture is applied automatically to all tests in the module.
* [`tests/test_fixture_autouse.py`](diffhunk://#diff-0156f3c4d5e7cee26f7700ce82174b965da58aed77751f31d0b14dc52e72d882R1-R50): Added `test_preloaded_row_count`, which verifies that the fixture inserted exactly two rows into the table.
* [`tests/test_fixture_autouse.py`](diffhunk://#diff-0156f3c4d5e7cee26f7700ce82174b965da58aed77751f31d0b14dc52e72d882R1-R50): Added `test_query_returns_expected_value`, which runs a SELECT query to ensure the correct row is returned based on the preloaded data.