### PR TITLE
Bump version to 0.5.0 in pyproject.toml and uv.lock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mockylla"
-version = "0.4.0"
+version = "0.5.0"
 description = "A mock for the ScyllaDB Python driver for testing purposes."
 readme = "README.md"
 requires-python = ">=3.8,<3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -169,7 +169,7 @@ wheels = [
 
 [[package]]
 name = "mockylla"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "scylla-driver" },


### PR DESCRIPTION
This pull request updates the version number of the `mockylla` package to reflect a new release.

- Version bump:
  * Updated the `version` field in `pyproject.toml` from `0.4.0` to `0.5.0`.